### PR TITLE
Comment out Debian boxes, add Ubuntu 18.04

### DIFF
--- a/vagrant/boxes.d/00-debian.yaml
+++ b/vagrant/boxes.d/00-debian.yaml
@@ -1,7 +1,10 @@
-debian9:
-  box_name: 'debian/stretch64'
-  image_name: !ruby/regexp '/Debian 9.*/'
-  pty: true
-  ansible:
-    variables:
-      ansible_python_interpreter: /usr/bin/python3
+# Debian 9 doesn't work because it uses Python 3.5 (< 3.6)
+# Uncomment this (and fix the box name) when Debian 10 is out
+
+# debian10:
+#   box_name: 'debian/stretch64'
+#   image_name: !ruby/regexp '/Debian 10.*/'
+#   pty: true
+#   ansible:
+#     variables:
+#       ansible_python_interpreter: /usr/bin/python3

--- a/vagrant/boxes.d/00-ubuntu.yaml
+++ b/vagrant/boxes.d/00-ubuntu.yaml
@@ -1,0 +1,6 @@
+# The only provider of Ubuntu 18.04 boxes ('generic' on vagrant cloud) disables IPv6
+# *at the kernel level* in the name of "compatibility" with many different backends.
+# The practical result of this is that you can't install redis, because redis tries
+# to set itself up on an IPv6 address while processing the post-install scripts.
+#
+# This can be re-evaluated at a later date.

--- a/vagrant/boxes.d/20-sandbox.yaml
+++ b/vagrant/boxes.d/20-sandbox.yaml
@@ -19,9 +19,9 @@ pulp3-sandbox-centos7:
     playbook: "ansible-pulp3/user-sandbox.yml"
     galaxy_role_file: "requirements.yml"
 
-pulp3-sandbox-debian9:
-  box: 'debian9'
-  memory: 2048
-  ansible:
-    playbook: "ansible-pulp3/user-sandbox.yml"
-    galaxy_role_file: "requirements.yml"
+# pulp3-sandbox-debian10:
+#   box: 'debian10'
+#   memory: 2048
+#   ansible:
+#     playbook: "ansible-pulp3/user-sandbox.yml"
+#     galaxy_role_file: "requirements.yml"

--- a/vagrant/boxes.d/30-source.yaml
+++ b/vagrant/boxes.d/30-source.yaml
@@ -31,13 +31,13 @@ pulp3-source-centos7:
     playbook: "ansible-pulp3/source-install.yml"
     galaxy_role_file: "requirements.yml"
 
-pulp3-source-debian9:
-  box: 'debian9'
-  sshfs:
-    host_path: '..'
-    guest_path: '/home/vagrant/devel'
-    reverse: False
-  memory: 2048
-  ansible:
-    playbook: "ansible-pulp3/source-install.yml"
-    galaxy_role_file: "requirements.yml"
+# pulp3-source-debian10:
+#   box: 'debian10'
+#   sshfs:
+#     host_path: '..'
+#     guest_path: '/home/vagrant/devel'
+#     reverse: False
+#   memory: 2048
+#   ansible:
+#     playbook: "ansible-pulp3/source-install.yml"
+#     galaxy_role_file: "requirements.yml"

--- a/vagrant/boxes.d/40-containers.yaml
+++ b/vagrant/boxes.d/40-containers.yaml
@@ -19,9 +19,9 @@ pulp3-containers-centos7:
     playbook: "ansible-pulp3/systemd-container.yaml"
     galaxy_role_file: "requirements.yml"
 
-pulp3-containers-debian9:
-  box: 'debian9'
-  memory: 2048
-  ansible:
-    playbook: "ansible-pulp3/systemd-container.yaml"
-    galaxy_role_file: "requirements.yml"
+# pulp3-containers-debian10:
+#   box: 'debian10'
+#   memory: 2048
+#   ansible:
+#     playbook: "ansible-pulp3/systemd-container.yaml"
+#     galaxy_role_file: "requirements.yml"


### PR DESCRIPTION
Debian 9 doesn't work because it ships with Python 3.5, which we don't support.

Leave it commented out for now.  Debian 10 will come this summer and we can re-enable it then.

Ubuntu 18.04 does ship with an acceptable Python version, though.