### PR TITLE
Take vagrant assets from ansible-pulp3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,11 @@ repo
 *.retry
 *.pyc
 user_playbooks
-playbooks/galaxy_roles
+playbooks/roles
 requirements.yml
+local.user-config.yml
+local.dev-config.yml
+
 
 # Vagrant
 .vagrant

--- a/example.dev-config.yml
+++ b/example.dev-config.yml
@@ -1,0 +1,24 @@
+# Options
+pulp_devel_supplement_bashrc: true
+pulp_default_admin_password: password
+pulp_secret_key: "unsafe_default"
+pulp_install_plugins:
+  # pulp-python:
+  #   app_label: "python"
+  #   source_dir: "/home/vagrant/devel/pulp_python"
+  # pulp-docker:
+  #   app_label: "docker"
+  #   source_dir: "/home/vagrant/devel/pulp_docker"
+  # pulp-rpm:
+  #   app_label: "rpm"
+  #   source_dir: "/home/vagrant/devel/pulp_rpm"
+  pulp-file:
+    app_label: "file"
+    source_dir: "/home/vagrant/devel/pulp_file"
+
+# Vagrant source install Required
+pulp_user: "vagrant"
+developer_user: "vagrant"
+developer_user_home: "/home/vagrant"
+pulp_plugin_source_dir: "/home/vagrant/devel/pulpcore-plugin"
+pulp_source_dir: "/home/vagrant/devel/pulp"

--- a/example.user-config.yml
+++ b/example.user-config.yml
@@ -1,0 +1,9 @@
+pulp_default_admin_password: password
+pulp_install_plugins:
+  # pulp-python:
+  #   app_label: "python"
+  # pulp-rpm:
+  #   app_label: "rpm"
+  pulp-file:
+    app_label: "file"
+pulp_secret_key: "unsafe_default"

--- a/playbooks/source-install.yml
+++ b/playbooks/source-install.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  vars:
+    paths_to_vars_files:
+    - '../local.dev-config.yml'
+    - '../example.dev-config.yml'
+  pre_tasks:
+    - include_vars: "{{ item }}"
+      with_first_found: "{{ paths_to_vars_files }}"
+    - name: Set up Vagrant machine for source installs
+      include: ../vagrant/vagrant-pretask.yml
+  roles:
+    - pulp3-postgresql
+    - pulp3-workers
+    - pulp3-resource-manager
+    - pulp3-webserver
+    - pulp3-content
+    - pulp3-devel

--- a/playbooks/user-sandbox.yml
+++ b/playbooks/user-sandbox.yml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  vars:
+    paths_to_vars_files:
+    - '../local.user-config.yml'
+    - '../example.user-config.yml'
+  pre_tasks:
+    - include_vars: "{{ item }}"
+      with_first_found: "{{ paths_to_vars_files }}"
+
+  roles:
+    - pulp3-postgresql
+    - pulp3-workers
+    - pulp3-resource-manager
+    - pulp3-webserver
+    - pulp3-content

--- a/vagrant/boxes.d/20-sandbox.yaml
+++ b/vagrant/boxes.d/20-sandbox.yaml
@@ -2,21 +2,21 @@ pulp3-sandbox-fedora28:
   box: 'fedora28'
   memory: 2048
   ansible:
-    playbook: "ansible-pulp3/user-sandbox.yml"
+    playbook: "playbooks/user-sandbox.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
 
 pulp3-sandbox-fedora29:
   box: 'fedora29'
   memory: 2048
   ansible:
-    playbook: "ansible-pulp3/user-sandbox.yml"
+    playbook: "playbooks/user-sandbox.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
 
 pulp3-sandbox-centos7:
   box: 'centos7'
   memory: 2048
   ansible:
-    playbook: "ansible-pulp3/user-sandbox.yml"
+    playbook: "playbooks/user-sandbox.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
 
 # pulp3-sandbox-debian10:

--- a/vagrant/boxes.d/30-source.yaml
+++ b/vagrant/boxes.d/30-source.yaml
@@ -6,7 +6,7 @@ pulp3-source-fedora28:
     reverse: False
   memory: 2048
   ansible:
-    playbook: "ansible-pulp3/source-install.yml"
+    playbook: "playbooks/source-install.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
 
 pulp3-source-fedora29:
@@ -17,7 +17,7 @@ pulp3-source-fedora29:
     reverse: False
   memory: 2048
   ansible:
-    playbook: "ansible-pulp3/source-install.yml"
+    playbook: "playbooks/source-install.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
 
 pulp3-source-centos7:
@@ -28,7 +28,7 @@ pulp3-source-centos7:
     reverse: False
   memory: 2048
   ansible:
-    playbook: "ansible-pulp3/source-install.yml"
+    playbook: "playbooks/source-install.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
 
 # pulp3-source-debian10:

--- a/vagrant/boxes.d/99-local.yaml.example
+++ b/vagrant/boxes.d/99-local.yaml.example
@@ -6,7 +6,7 @@ centos7-pulp3-source:
     host_path: ~/dev/nfs/centos7-pulp3-source/
     guest_path: /home/vagrant/nfs/
   ansible:
-    playbook: "ansible-pulp3/source-install.yml"
+    playbook: "playbooks/source-install.yml"
     galaxy_role_file: "ansible-pulp3/requirements.yml"
     verbose: vv
     variables:

--- a/vagrant/vagrant-pretask.yml
+++ b/vagrant/vagrant-pretask.yml
@@ -1,0 +1,7 @@
+---
+- name: (Vagrant) Make user's home directory world-readable
+  file:
+    path: "{{ ansible_env.HOME }}"
+    state: directory
+    mode: 0755
+  become: true


### PR DESCRIPTION
This is the companion of https://github.com/pulp/ansible-pulp3/pull/77

The way this will work is that pulplift users will not specify their own playbooks, but will use the playbooks provided (this is how pulplift currently works with ansible-pulp3). The new feature is that pulplift will run out-of-the-box by using one of the example yaml files that contain ansible vars. The pulplift user can copy these files to local.example...(not checked into git) and pulplift will use that instead.