### PR TITLE
README.md:  update list of boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ The aim is to provide every supported OS and major installation type combination
 
 ```
 centos7                   not created (libvirt)
-fedora27                  not created (libvirt)
+centos7-fips              not created (libvirt)
 fedora28                  not created (libvirt)
+fedora29                  not created (libvirt)
+pulp3-containers-centos7  not created (libvirt)
+pulp3-containers-fedora28 not created (libvirt)
+pulp3-containers-fedora29 not created (libvirt)
 pulp3-sandbox-centos7     not created (libvirt)
-pulp3-sandbox-fedora27    not created (libvirt)
 pulp3-sandbox-fedora28    not created (libvirt)
+pulp3-sandbox-fedora29    not created (libvirt)
 pulp3-source-centos7      not created (libvirt)
-pulp3-source-fedora27     not created (libvirt)
 pulp3-source-fedora28     not created (libvirt)
+pulp3-source-fedora29     not created (libvirt)
 ```
 
 Any of the `pulp3` labeled boxes will both spin-up and provision the labeled Ansible installation scenario for Pulp 3. The base OS boxes, such as centos7, can be used to spin-up a clean environment that any existing or custom playbook is run against directly. For example:


### PR DESCRIPTION
I'm not sure if we want to list the containers at this time, or centos7-fips,
but this is the current list of boxes according to `vagrant status`.