### PR TITLE
Add examples for certguard, ansible, and docker

### DIFF
--- a/example.dev-config.yml
+++ b/example.dev-config.yml
@@ -3,12 +3,18 @@ pulp_devel_supplement_bashrc: true
 pulp_default_admin_password: password
 pulp_secret_key: "unsafe_default"
 pulp_install_plugins:
-  # pulp-python:
-  #   app_label: "python"
-  #   source_dir: "/home/vagrant/devel/pulp_python"
+  # pulp-ansible:
+  #   app_label: "ansible"
+  #   source_dir: "/home/vagrant/devel/pulp_ansible"
+  # pulp-certguard:
+  #   app_label: "certguard"
+  #   source_dir: "/home/vagrant/devel/pulp-certguard"
   # pulp-docker:
   #   app_label: "docker"
   #   source_dir: "/home/vagrant/devel/pulp_docker"
+  # pulp-python:
+  #   app_label: "python"
+  #   source_dir: "/home/vagrant/devel/pulp_python"
   # pulp-rpm:
   #   app_label: "rpm"
   #   source_dir: "/home/vagrant/devel/pulp_rpm"

--- a/example.user-config.yml
+++ b/example.user-config.yml
@@ -1,5 +1,11 @@
 pulp_default_admin_password: password
 pulp_install_plugins:
+  # pulp-ansible:
+  #   app_label: "ansible"
+  # pulp-certguard:
+  #   app_label: "certguard"
+  # pulp-docker:
+  #   app_label: "docker"
   # pulp-python:
   #   app_label: "python"
   # pulp-rpm:


### PR DESCRIPTION
These are commented out examples that would install the pulp-certguard,
pulp-ansible, and pulp-docker packages in either source or pypi
installs.

[noissue]