### PR TITLE
Add commented debian plugin configs

### DIFF
--- a/example.dev-config.yml
+++ b/example.dev-config.yml
@@ -9,6 +9,9 @@ pulp_install_plugins:
   # pulp-certguard:
   #   app_label: "certguard"
   #   source_dir: "/home/vagrant/devel/pulp-certguard"
+  # pulp-deb:
+  #   app_label: "deb"
+  #   source_dir: "/home/vagrant/devel/pulp_deb"
   # pulp-docker:
   #   app_label: "docker"
   #   source_dir: "/home/vagrant/devel/pulp_docker"

--- a/example.user-config.yml
+++ b/example.user-config.yml
@@ -4,6 +4,8 @@ pulp_install_plugins:
   #   app_label: "ansible"
   # pulp-certguard:
   #   app_label: "certguard"
+  # pulp-deb:
+  #   app_label: "deb"
   # pulp-docker:
   #   app_label: "docker"
   # pulp-python:


### PR DESCRIPTION
I was able to use this config to vagrant up into a working pulp_deb
plugin environment from source. This should allow other users to do the
same with less effort.

[noissue]