### PR TITLE
Add a check for submodule consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+git:
+  submodules: true
+script:
+  - repo_checks/submodule_check.sh

--- a/repo_checks/submodule_check.sh
+++ b/repo_checks/submodule_check.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+echo "Check whether submodule commits are on their corresponding master branches."
+git submodule foreach "git branch --all --format '%(refname:lstrip=-1)' --contains | grep -q '^master$'"


### PR DESCRIPTION
This checks, whether commits of the submodule are available on the
master branch of the submodule, to ensure their future availability.

[noissue]