### PR TITLE
Problem: pulp-rpm-prerequisites (git) and pulp.pulp_rpm_prerequisites…

### DIFF
--- a/example.dev-config.yml
+++ b/example.dev-config.yml
@@ -20,7 +20,10 @@ pulp_install_plugins:
   #   source_dir: "/home/vagrant/devel/pulp_python"
   # pulp-rpm:
   #   source_dir: "/home/vagrant/devel/pulp_rpm"
-  #   prereq_role: "/home/vagrant/devel/pulp-rpm-prerequisites"
+  # # You can specify a folderpath to pulp.pulp_rpm_prerequisites instead of
+  # # just uncommenting this role name, but note that it is a path on the
+  # # pulplift host, not the guest VM like all the other paths.
+  #   prereq_role: "pulp.pulp_rpm_prerequisites"
   pulp-file:
     source_dir: "/home/vagrant/devel/pulp_file"
 

--- a/example.user-config.yml
+++ b/example.user-config.yml
@@ -9,7 +9,7 @@ pulp_install_plugins:
   # pulp-maven: {}
   # pulp-python: {}
   # pulp-rpm:
-  #   prereq_role: "/home/vagrant/devel/pulp-rpm-prerequisites"
+  #   prereq_role: "pulp.pulp_rpm_prerequisites"
   pulp-file: {}
 
 # Uncomment if using pulp-rpm


### PR DESCRIPTION
… (galaxy) are inconsistently named

Solution: Git repo was renamed to underscores, now update the example
pulplift config for it.

Also replace the old path that never worked with just the role name,
and document what the correct path should be.

Also refresh 3rd party repos.

re: #5619
pulp-rpm-prerequisites (git) and pulp.pulp_rpm_prerequisites (galaxy) are inconsistently named
https://pulp.plan.io/issues/5619

[noissue]