### PR TITLE
Problem: provisioning is slower than it could be

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,6 @@ allow_world_readable_tmpfiles = True
 
 [privilege_escalation]
 become = True
+
+[ssh_connection]
+pipelining = True


### PR DESCRIPTION
Solution: Enable ansible pipelining. It's safe to do on all our
current boxes. If it ever isn't safe to do for 1, we can use this
role to conditionally enable it:
https://galaxy.ansible.com/gzm55/smart_ssh_pipelining

On my quick test (file module loop to touch /tmp/[1-20], it reduced
the time per loop item from .41s .21s. Tasks without a loop
receive a similar reduction in overhead.

re: #5817
ansible-pulp CI is slower than it should be due to a lack of ansible pipelining
https://pulp.plan.io/issues/5817