### PR TITLE
Removing galaxy-pulp from example

### DIFF
--- a/example.dev-config.yml
+++ b/example.dev-config.yml
@@ -4,8 +4,6 @@ pulp_default_admin_password: password
 pulp_install_plugins:
   # pulp-ansible:
   #   source_dir: "/home/vagrant/devel/pulp_ansible"
-  # galaxy-pulp:
-  #   source_dir: "/home/vagrant/devel/galaxy_ng/bindings/galaxy-pulp"
   # galaxy-ng:
   #   source_dir: "/home/vagrant/devel/galaxy_ng"
   # pulp-certguard:

--- a/example.user-config.yml
+++ b/example.user-config.yml
@@ -1,7 +1,6 @@
 pulp_default_admin_password: password
 pulp_install_plugins:
   # pulp-ansible: {}
-  # galaxy-pulp: {}
   # galaxy-ng: {}
   # pulp-certguard: {}
   # pulp-cookbook: {}


### PR DESCRIPTION
With https://github.com/ansible/galaxy_ng/pull/56
there is no need for galaxy-pulp on example