### PR TITLE
Implement CI based on hardware KVM on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,27 @@
+---
+language: python
+dist: focal
 git:
   submodules: true
-script:
+before_install:
   - repo_checks/submodule_check.sh
+install:
+  - git submodule update --remote
+  - .travis/install.sh
+script:
+  - .travis/script.sh $TEST
+jobs:
+  include:
+  # - env: TEST=pulp2-nightly-pulp3-source-centos7 # Not enough RAM
+    - env: TEST=pulp3-sandbox-centos7
+    - env: TEST=pulp3-sandbox-centos7-fips
+    - env: TEST=pulp3-sandbox-centos8-stream
+    - env: TEST=pulp3-sandbox-debian10
+    - env: TEST=pulp3-sandbox-fedora31
+    - env: TEST=pulp3-sandbox-fedora32
+    - env: TEST=pulp3-source-centos7
+    - env: TEST=pulp3-source-centos7-fips
+    - env: TEST=pulp3-source-centos8-stream
+    - env: TEST=pulp3-source-debian10
+    - env: TEST=pulp3-source-fedora31
+    - env: TEST=pulp3-source-fedora32

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -xmveuo pipefail
+
+sudo apt update
+
+# Updating vagrant-sshfs is necessary to support CentOS 7,8 without repos pre-configured.
+curl --output vagrant-sshfs_1.3.4-1_all.deb http://ftp.br.debian.org/debian/pool/main/v/vagrant-sshfs/vagrant-sshfs_1.3.4-1_all.deb
+sudo apt install ./vagrant-sshfs_1.3.4-1_all.deb
+rm ./vagrant-sshfs_1.3.4-1_all.deb
+
+sudo apt install software-properties-common openssh-server vagrant-libvirt libvirt-daemon-system vagrant-sshfs qemu-utils qemu-kvm cpu-checker dnsmasq
+# This PPA doesn't exist for 20.04 (focal)
+if grep -i bionic /etc/os-release ; then
+  sudo apt-add-repository --yes --update ppa:ansible/ansible
+fi
+
+# Updating ansible past 2.9.6 (to 2.9.8+) is necessary to manage Fedora 32:
+# https://github.com/ansible/ansible/pull/68211
+if grep -i focal /etc/os-release ; then
+  curl --output ansible_2.9.9+dfsg-1_all.deb http://ftp.br.debian.org/debian/pool/main/a/ansible/ansible_2.9.9+dfsg-1_all.deb
+  sudo apt install ./ansible_2.9.9+dfsg-1_all.deb
+  sudo rm ./ansible_2.9.9+dfsg-1_all.deb
+fi
+
+sudo apt install ansible
+sudo kvm-ok
+sudo usermod -a -G libvirt $USER
+sudo systemctl enable --now ssh
+sudo systemctl enable --now libvirtd
+# newgrp - libvirt # This causes Travis to hang, with or without the dash
+
+free -m
+df -h
+df -hl
+cat /proc/cpuinfo
+sudo apt install virt-what
+sudo virt-what
+
+# For the source tests
+cd ..
+git clone https://github.com/pulp/pulpcore
+git clone https://github.com/pulp/pulp_file

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -xmveuo pipefail
+
+unset GEM_PATH
+unset GEM_HOME
+# We do this because we could not set newgrp earlier
+sudo vagrant up $1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sudo virt-host-validate
 Before using Pulplift, ensure that all submodules are updated and in place.
 
 ```
-git submodule update --init
+git submodule update --init --remote
 ```
 
 After your git submodules are installed, you can then use ``vagrant up <box-name>`` to create a Pulp

--- a/playbooks/pre_tasks/vagrant-workarounds.yml
+++ b/playbooks/pre_tasks/vagrant-workarounds.yml
@@ -43,3 +43,14 @@
   when:
     - (ansible_distribution == 'CentOS') or (ansible_distribution == 'RedHat')
     - ansible_distribution_major_version|int == 8
+
+- name: Upgrade CentOS 7 FIPS box
+  yum:
+    name: "*"
+    state: latest
+  when:
+    - (ansible_distribution == 'CentOS') or (ansible_distribution == 'RedHat')
+    - ansible_distribution_version is version("7.6", "<=")
+
+- name: Refresh facts for OS upgrade
+  setup:

--- a/vagrant/boxes.d/20-sandbox.yaml
+++ b/vagrant/boxes.d/20-sandbox.yaml
@@ -1,5 +1,6 @@
 pulp3-sandbox-fedora31:
   box: 'fedora31'
+  hostname: pulp3-sandbox-fedora31.lan
   memory: 4096
   ansible:
     playbook: "playbooks/user-sandbox.yml"
@@ -7,6 +8,7 @@ pulp3-sandbox-fedora31:
 
 pulp3-sandbox-fedora32:
   box: 'fedora32'
+  hostname: pulp3-sandbox-fedora32.lan
   memory: 4096
   ansible:
     playbook: "playbooks/user-sandbox.yml"
@@ -14,6 +16,7 @@ pulp3-sandbox-fedora32:
 
 pulp3-sandbox-centos7:
   box: 'centos7'
+  hostname: pulp3-sandbox-centos7.lan
   memory: 4096
   ansible:
     playbook: "playbooks/user-sandbox.yml"
@@ -21,6 +24,7 @@ pulp3-sandbox-centos7:
 
 pulp3-sandbox-centos7-fips:
   box: 'centos7-fips'
+  hostname: pulp3-sandbox-centos7-fips.lan
   memory: 4096
   ansible:
     playbook: "playbooks/user-sandbox.yml"
@@ -29,6 +33,7 @@ pulp3-sandbox-centos7-fips:
 pulp3-sandbox-centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'
+  hostname: pulp3-sandbox-centos8-stream.lan
   memory: 4096
   ansible:
     playbook: "playbooks/user-sandbox.yml"
@@ -36,6 +41,7 @@ pulp3-sandbox-centos8-stream:
 
 pulp3-sandbox-debian10:
   box: 'debian10'
+  hostname: pulp3-sandbox-debian10.lan
   memory: 4096
   ansible:
     playbook: "playbooks/user-sandbox.yml"

--- a/vagrant/boxes.d/30-source.yaml
+++ b/vagrant/boxes.d/30-source.yaml
@@ -1,5 +1,6 @@
 pulp3-source-fedora31:
   box: 'fedora31'
+  hostname: pulp3-source-fedora31.lan
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -11,6 +12,7 @@ pulp3-source-fedora31:
 
 pulp3-source-fedora32:
   box: 'fedora32'
+  hostname: pulp3-source-fedora32.lan
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -22,6 +24,7 @@ pulp3-source-fedora32:
 
 pulp3-source-centos7:
   box: 'centos7'
+  hostname: pulp3-source-centos7.lan
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -33,6 +36,7 @@ pulp3-source-centos7:
 
 pulp2-nightly-pulp3-source-centos7:
   box: 'centos7'
+  hostname: pulp2-nightly-pulp3-source-centos7.lan
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -51,6 +55,7 @@ pulp2-nightly-pulp3-source-centos7:
 
 pulp3-source-centos7-fips:
   box: 'centos7-fips'
+  hostname: pulp3-source-centos7-fips.lan
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -63,6 +68,7 @@ pulp3-source-centos7-fips:
 pulp3-source-centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'
+  hostname: pulp3-source-centos8-stream.lan
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -72,6 +78,10 @@ pulp3-source-centos8-stream:
     playbook: "playbooks/source-install.yml"
     galaxy_role_file: "pulp_installer/requirements.yml"
 
+# No need to specify hostname; this box doesn't fail with the 64 character
+# hostname limit on travis for some reason. even though
+# "pulp3-source-debian10.$(hostname -f)" on the travis host host would be over
+# 64 chars.
 pulp3-source-debian10:
   box: 'debian10'
   sshfs:


### PR DESCRIPTION
Runs at Pull Request time.

Will be scheduled to run as a cronjob.

Always pulls the latest of the upstream branches, specific
commits receive no additional testing.

Does not test pulp2-nightly-pulp3-source-centos7 yet;
may be feasible and fast enough if we try adjusting the RAM
and creating a swapfile.