### PR TITLE
Centos8 fips

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,14 @@ jobs:
     - env: TEST=pulp2-nightly-pulp3-source-centos7
     - env: TEST=pulp3-sandbox-centos7
     - env: TEST=pulp3-sandbox-centos7-fips
+    - env: TEST=pulp3-sandbox-centos8
     - env: TEST=pulp3-sandbox-centos8-stream
     - env: TEST=pulp3-sandbox-debian10
     - env: TEST=pulp3-sandbox-fedora31
     - env: TEST=pulp3-sandbox-fedora32
     - env: TEST=pulp3-source-centos7
     - env: TEST=pulp3-source-centos7-fips
+    - env: TEST=pulp3-source-centos8
     - env: TEST=pulp3-source-centos8-stream
     - env: TEST=pulp3-source-debian10
     - env: TEST=pulp3-source-fedora31

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
     - env: TEST=pulp3-sandbox-centos7
     - env: TEST=pulp3-sandbox-centos7-fips
     - env: TEST=pulp3-sandbox-centos8
+    - env: TEST=pulp3-sandbox-centos8-fips
     - env: TEST=pulp3-sandbox-centos8-stream
     - env: TEST=pulp3-sandbox-debian10
     - env: TEST=pulp3-sandbox-fedora31
@@ -23,6 +24,7 @@ jobs:
     - env: TEST=pulp3-source-centos7
     - env: TEST=pulp3-source-centos7-fips
     - env: TEST=pulp3-source-centos8
+    - env: TEST=pulp3-source-centos8-fips
     - env: TEST=pulp3-source-centos8-stream
     - env: TEST=pulp3-source-debian10
     - env: TEST=pulp3-source-fedora31

--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -16,6 +16,10 @@ centos8:
   box_url:    'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
   pty:        true
 
+centos8-fips:
+  box_name:   'pulp/centos8-fips'
+  pty:        true
+
 centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'

--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -10,6 +10,12 @@ centos7-fips:
   box_name: 'pulp/centos7-fips'
   pty: true
 
+centos8:
+  box_name:   'centos/82'
+  # vagrantcloud still has 8.1. We've asked CentOS to register this URL with it.
+  box_url:    'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
+  pty:        true
+
 centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'

--- a/vagrant/boxes.d/20-sandbox.yaml
+++ b/vagrant/boxes.d/20-sandbox.yaml
@@ -30,6 +30,15 @@ pulp3-sandbox-centos7-fips:
     playbook: "playbooks/user-sandbox.yml"
     galaxy_role_file: "pulp_installer/requirements.yml"
 
+pulp3-sandbox-centos8:
+  box_name:   'centos/82'
+  box_url:    'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
+  hostname: pulp3-sandbox-centos8.lan
+  memory: 4096
+  ansible:
+    playbook: "playbooks/user-sandbox.yml"
+    galaxy_role_file: "pulp_installer/requirements.yml"
+
 pulp3-sandbox-centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'

--- a/vagrant/boxes.d/20-sandbox.yaml
+++ b/vagrant/boxes.d/20-sandbox.yaml
@@ -39,6 +39,14 @@ pulp3-sandbox-centos8:
     playbook: "playbooks/user-sandbox.yml"
     galaxy_role_file: "pulp_installer/requirements.yml"
 
+pulp3-sandbox-centos8-fips:
+  box_name:   'pulp/centos8-fips'
+  hostname: pulp3-sandbox-centos8-fips.lan
+  memory: 4096
+  ansible:
+    playbook: "playbooks/user-sandbox.yml"
+    galaxy_role_file: "pulp_installer/requirements.yml"
+
 pulp3-sandbox-centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'

--- a/vagrant/boxes.d/30-source.yaml
+++ b/vagrant/boxes.d/30-source.yaml
@@ -66,6 +66,19 @@ pulp3-source-centos7-fips:
     playbook: "playbooks/source-install.yml"
     galaxy_role_file: "pulp_installer/requirements.yml"
 
+pulp3-source-centos8:
+  box_name:   'centos/82'
+  box_url:    'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
+  hostname: pulp3-source-centos8.lan
+  sshfs:
+    host_path: '..'
+    guest_path: '/home/vagrant/devel'
+    reverse: False
+  memory: 4096
+  ansible:
+    playbook: "playbooks/source-install.yml"
+    galaxy_role_file: "pulp_installer/requirements.yml"
+
 pulp3-source-centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'

--- a/vagrant/boxes.d/30-source.yaml
+++ b/vagrant/boxes.d/30-source.yaml
@@ -79,6 +79,18 @@ pulp3-source-centos8:
     playbook: "playbooks/source-install.yml"
     galaxy_role_file: "pulp_installer/requirements.yml"
 
+pulp3-source-centos8-fips:
+  box_name:   'pulp/centos8-fips'
+  hostname: pulp3-source-centos8-fips.lan
+  sshfs:
+    host_path: '..'
+    guest_path: '/home/vagrant/devel'
+    reverse: False
+  memory: 4096
+  ansible:
+    playbook: "playbooks/source-install.yml"
+    galaxy_role_file: "pulp_installer/requirements.yml"
+
 pulp3-source-centos8-stream:
   box_name:   'centos/8-stream'
   box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'


### PR DESCRIPTION
This adds both CentOS 8.2 as "centos8", and our CentOS 8.2 FIPS box "centos8-fips".

Both are added to CI.

centos8-fips was ultimately created with:
https://github.com/daviddavis/fips-box-builder

Instead of the "centos8" box.

Contains workaround for SSH authentication between vagrant
(with net-ssh prior to 6.2) and CentOS8 with FIPS enabled.